### PR TITLE
feat: add chess board ui skeleton

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,341 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  BOARD_SIZE,
+  createInitialBoard,
+  getLegalMoves,
+  movePiece,
+} from "./chess/engine.js";
+
+const PIECE_SYMBOLS = {
+  pawn: { white: "♙", black: "♟︎" },
+  rook: { white: "♖", black: "♜" },
+  knight: { white: "♘", black: "♞" },
+  bishop: { white: "♗", black: "♝" },
+  queen: { white: "♕", black: "♛" },
+  king: { white: "♔", black: "♚" },
+};
+
+const INITIAL_TIME = 5 * 60;
+
+const formatSquare = ({ row, col }) => `${String.fromCharCode(97 + col)}${
+  BOARD_SIZE - row
+}`;
+
+const formatTime = (seconds) => {
+  const mm = String(Math.floor(seconds / 60)).padStart(2, "0");
+  const ss = String(seconds % 60).padStart(2, "0");
+  return `${mm}:${ss}`;
+};
+
+const pieceNameRu = {
+  pawn: "пешка",
+  rook: "ладья",
+  knight: "конь",
+  bishop: "слон",
+  queen: "ферзь",
+  king: "король",
+};
+
+const colorNameRu = {
+  white: "Белые",
+  black: "Черные",
+};
+
+function App() {
+  const [board, setBoard] = useState(() => createInitialBoard());
+  const [selected, setSelected] = useState(null);
+  const [legalMoves, setLegalMoves] = useState([]);
+  const [moveHistory, setMoveHistory] = useState([]);
+  const [activeColor, setActiveColor] = useState("white");
+  const [timers, setTimers] = useState({ white: INITIAL_TIME, black: INITIAL_TIME });
+  const [isGameOver, setIsGameOver] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("Белые делают первый ход.");
+
+  useEffect(() => {
+    if (isGameOver) return undefined;
+    const timer = setInterval(() => {
+      setTimers((prev) => {
+        const remaining = prev[activeColor];
+        if (remaining <= 0) {
+          clearInterval(timer);
+          return prev;
+        }
+        const nextValue = Math.max(0, remaining - 1);
+        if (nextValue === 0) {
+          setSelected(null);
+          setLegalMoves([]);
+          setIsGameOver(true);
+          setStatusMessage(
+            `${colorNameRu[activeColor]} проиграли по времени. Победа ${
+              colorNameRu[activeColor === "white" ? "black" : "white"]
+            }.`
+          );
+        }
+        return { ...prev, [activeColor]: nextValue };
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [activeColor, isGameOver]);
+
+  const legalMoveMap = useMemo(() => {
+    const map = new Map();
+    legalMoves.forEach((move) => {
+      map.set(`${move.row}:${move.col}`, move);
+    });
+    return map;
+  }, [legalMoves]);
+
+  const handleSquareClick = (row, col) => {
+    if (isGameOver) return;
+
+    const piece = board[row][col];
+    if (selected && selected.row === row && selected.col === col) {
+      setSelected(null);
+      setLegalMoves([]);
+      return;
+    }
+
+    if (piece && piece.color === activeColor) {
+      setSelected({ row, col });
+      setLegalMoves(getLegalMoves(board, { row, col }));
+      return;
+    }
+
+    if (!selected) return;
+
+    const key = `${row}:${col}`;
+    if (!legalMoveMap.has(key)) return;
+
+    const movingPiece = board[selected.row][selected.col];
+    const capturedPiece = board[row][col];
+    const nextBoard = movePiece(board, selected, { row, col });
+
+    setBoard(nextBoard);
+    setSelected(null);
+    setLegalMoves([]);
+
+    const moveNumber = Math.floor(moveHistory.length / 2) + 1;
+    const fromNotation = formatSquare(selected);
+    const toNotation = formatSquare({ row, col });
+    const captureSuffix = capturedPiece ? " ×" : "";
+    const notation = `${moveNumber}. ${colorNameRu[movingPiece.color]} ${
+      PIECE_SYMBOLS[movingPiece.type][movingPiece.color]
+    } ${fromNotation}→${toNotation}${captureSuffix}`;
+
+    setMoveHistory((prev) => [...prev, notation]);
+
+    if (capturedPiece?.type === "king") {
+      setIsGameOver(true);
+      setStatusMessage(`${colorNameRu[movingPiece.color]} объявляют мат!`);
+    } else {
+      const nextColor = activeColor === "white" ? "black" : "white";
+      setActiveColor(nextColor);
+      setStatusMessage(`Ход ${colorNameRu[nextColor]}.`);
+    }
+  };
+
+  const handleNewGame = () => {
+    setBoard(createInitialBoard());
+    setSelected(null);
+    setLegalMoves([]);
+    setMoveHistory([]);
+    setActiveColor("white");
+    setTimers({ white: INITIAL_TIME, black: INITIAL_TIME });
+    setIsGameOver(false);
+    setStatusMessage("Белые делают первый ход.");
+  };
+
+  const handleResign = () => {
+    if (isGameOver) return;
+    const winnerColor = activeColor === "white" ? "black" : "white";
+    const winner = colorNameRu[winnerColor];
+    setSelected(null);
+    setLegalMoves([]);
+    setIsGameOver(true);
+    setStatusMessage(`${colorNameRu[activeColor]} сдались. Победа ${winner}.`);
+  };
+
+  const handleDraw = () => {
+    if (isGameOver) return;
+    setSelected(null);
+    setLegalMoves([]);
+    setIsGameOver(true);
+    setStatusMessage("Партия завершилась ничьей по соглашению.");
+  };
+
+  const renderSquare = (row, col) => {
+    const piece = board[row][col];
+    const isDark = (row + col) % 2 === 1;
+    const isSelected = selected && selected.row === row && selected.col === col;
+    const move = legalMoveMap.get(`${row}:${col}`);
+
+    const baseClasses = isDark ? "bg-emerald-900/60" : "bg-emerald-200/50";
+    const selectedClasses = isSelected ? "ring-4 ring-yellow-400" : "";
+    return (
+      <button
+        key={`${row}-${col}`}
+        type="button"
+        onClick={() => handleSquareClick(row, col)}
+        className={`relative flex h-16 w-16 items-center justify-center text-3xl transition ${baseClasses} ${selectedClasses}`}
+      >
+        {move && !move.capture && (
+          <span className={`absolute h-3 w-3 rounded-full bg-yellow-400/70`} />
+        )}
+        {move && move.capture && (
+          <span className={`absolute h-5 w-5 rounded-full border-4 border-yellow-400`} />
+        )}
+        {piece ? PIECE_SYMBOLS[piece.type][piece.color] : null}
+      </button>
+    );
+  };
+
+  const sidePanel = (
+    <aside className="flex w-full max-w-sm flex-col gap-6 rounded-xl border border-slate-800 bg-slate-900/60 p-6">
+      <div>
+        <h2 className="text-lg font-semibold text-slate-100">Информация о партии</h2>
+        <p className="mt-2 text-sm text-slate-300">{statusMessage}</p>
+      </div>
+      <div className="grid grid-cols-2 gap-4 text-center">
+        {(["white", "black"]).map((color) => (
+          <div
+            key={color}
+            className={`rounded-lg border p-4 ${
+              activeColor === color && !isGameOver
+                ? "border-emerald-400 bg-emerald-500/10"
+                : "border-slate-700 bg-slate-800/60"
+            }`}
+          >
+            <p className="text-sm uppercase tracking-wide text-slate-400">
+              {colorNameRu[color]}
+            </p>
+            <p className="mt-2 font-mono text-3xl">
+              {formatTime(timers[color])}
+            </p>
+          </div>
+        ))}
+      </div>
+      <div>
+        <h3 className="text-lg font-semibold text-slate-100">Ходы</h3>
+        <div className="mt-2 max-h-60 overflow-y-auto rounded-lg border border-slate-800 bg-slate-950/60 p-3 text-sm text-slate-300">
+          {moveHistory.length === 0 ? (
+            <p className="text-slate-500">Сделайте первый ход, чтобы начать запись партии.</p>
+          ) : (
+            <ol className="list-decimal space-y-2 pl-4">
+              {moveHistory.map((move) => (
+                <li key={move}>{move}</li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="button"
+          onClick={handleNewGame}
+          className="flex-1 rounded-lg bg-emerald-500 px-4 py-2 font-semibold text-emerald-950 transition hover:bg-emerald-400"
+        >
+          Новая игра
+        </button>
+        <button
+          type="button"
+          onClick={handleResign}
+          className="flex-1 rounded-lg border border-red-400 px-4 py-2 font-semibold text-red-400 transition hover:bg-red-500/10"
+        >
+          Сдаться
+        </button>
+        <button
+          type="button"
+          onClick={handleDraw}
+          className="flex-1 rounded-lg border border-slate-600 px-4 py-2 font-semibold text-slate-300 transition hover:bg-slate-700/60"
+        >
+          Ничья
+        </button>
+      </div>
+      <div>
+        <h3 className="text-lg font-semibold text-slate-100">Памятка по фигурам</h3>
+        <ul className="mt-2 space-y-2 text-sm text-slate-300">
+          {Object.entries(pieceNameRu).map(([type, name]) => (
+            <li key={type} className="flex items-center justify-between rounded-lg border border-slate-800 bg-slate-950/40 px-3 py-2">
+              <span className="font-medium capitalize">{name}</span>
+              <span className="text-2xl">
+                {PIECE_SYMBOLS[type].white}
+                <span className="mx-2 text-slate-500">/</span>
+                {PIECE_SYMBOLS[type].black}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </aside>
+  );
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      <header className="border-b border-slate-800 bg-slate-900/80 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+          <div>
+            <p className="text-sm uppercase tracking-[0.3em] text-emerald-400">Проект</p>
+            <h1 className="text-2xl font-semibold text-slate-100">Chess Online</h1>
+          </div>
+          <nav className="flex items-center gap-4 text-sm text-slate-300">
+            <a className="transition hover:text-emerald-400" href="#board">
+              Игра
+            </a>
+            <a className="transition hover:text-emerald-400" href="#about">
+              Планы
+            </a>
+            <a className="transition hover:text-emerald-400" href="#community">
+              Сообщество
+            </a>
+          </nav>
+        </div>
+      </header>
+      <main className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 lg:flex-row">
+        <section id="board" className="flex flex-1 flex-col items-center gap-6">
+          <div className="flex w-full flex-col items-center gap-4 rounded-3xl border border-slate-800 bg-slate-900/60 p-6 shadow-xl shadow-emerald-500/10">
+            <div className="flex w-full items-center justify-between">
+              <div className="text-left">
+                <p className="text-sm uppercase tracking-widest text-slate-400">Текущий ход</p>
+                <p className="text-xl font-semibold text-emerald-300">
+                  {colorNameRu[activeColor]}
+                </p>
+              </div>
+              <div className="rounded-full border border-emerald-500 px-4 py-1 text-sm text-emerald-200">
+                Бета-версия интерфейса
+              </div>
+            </div>
+            <div className="grid grid-cols-8 gap-1 rounded-2xl border border-emerald-500/30 bg-emerald-950/40 p-3">
+              {Array.from({ length: BOARD_SIZE }, (_, row) => (
+                <div key={row} className="contents">
+                  {Array.from({ length: BOARD_SIZE }, (_, col) => renderSquare(row, col))}
+                </div>
+              ))}
+            </div>
+          </div>
+          <section
+            id="about"
+            className="w-full rounded-2xl border border-slate-800 bg-slate-900/60 p-6 text-slate-300"
+          >
+            <h2 className="text-xl font-semibold text-slate-100">Дорожная карта развития</h2>
+            <ul className="mt-4 list-disc space-y-2 pl-6">
+              <li>Подключение серверной части и WebSocket для онлайн-матчей.</li>
+              <li>Авторизация игроков, рейтинги и профиль с историей партий.</li>
+              <li>Анализ позиций движком, тренировки тактики и турниры.</li>
+              <li>Мобильные клиенты, уведомления и расширенная модерация.</li>
+            </ul>
+          </section>
+        </section>
+        {sidePanel}
+      </main>
+      <footer
+        id="community"
+        className="border-t border-slate-800 bg-slate-900/80 py-6 text-center text-sm text-slate-400"
+      >
+        Присоединяйтесь к сообществу разработчиков Chess Online и помогайте строить
+        альтернативу chess.com!
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/chess/engine.js
+++ b/src/chess/engine.js
@@ -1,0 +1,183 @@
+export const BOARD_SIZE = 8;
+
+export const createInitialBoard = () => {
+  const emptyRow = () => Array.from({ length: BOARD_SIZE }, () => null);
+  const board = Array.from({ length: BOARD_SIZE }, emptyRow);
+
+  const backRank = [
+    "rook",
+    "knight",
+    "bishop",
+    "queen",
+    "king",
+    "bishop",
+    "knight",
+    "rook",
+  ];
+
+  backRank.forEach((type, col) => {
+    board[0][col] = { type, color: "black", hasMoved: false };
+    board[7][col] = { type, color: "white", hasMoved: false };
+  });
+
+  for (let col = 0; col < BOARD_SIZE; col += 1) {
+    board[1][col] = { type: "pawn", color: "black", hasMoved: false };
+    board[6][col] = { type: "pawn", color: "white", hasMoved: false };
+  }
+
+  return board;
+};
+
+export const cloneBoard = (board) =>
+  board.map((row) => row.map((square) => (square ? { ...square } : null)));
+
+const isInsideBoard = (row, col) =>
+  row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
+
+const pushIfValid = (board, moves, row, col, color, options = {}) => {
+  if (!isInsideBoard(row, col)) return false;
+  const target = board[row][col];
+  if (!target) {
+    moves.push({ row, col, capture: false, ...options });
+    return true;
+  }
+  if (target.color !== color) {
+    moves.push({ row, col, capture: true, ...options });
+  }
+  return false;
+};
+
+const getSlidingMoves = (board, from, color, directions) => {
+  const moves = [];
+  directions.forEach(([dr, dc]) => {
+    let row = from.row + dr;
+    let col = from.col + dc;
+    while (isInsideBoard(row, col)) {
+      const canContinue = pushIfValid(board, moves, row, col, color);
+      if (!canContinue) break;
+      row += dr;
+      col += dc;
+    }
+  });
+  return moves;
+};
+
+export const getLegalMoves = (board, from) => {
+  const piece = board[from.row][from.col];
+  if (!piece) return [];
+  const moves = [];
+
+  switch (piece.type) {
+    case "pawn": {
+      const direction = piece.color === "white" ? -1 : 1;
+      const startRow = piece.color === "white" ? 6 : 1;
+      const nextRow = from.row + direction;
+      if (isInsideBoard(nextRow, from.col) && !board[nextRow][from.col]) {
+        moves.push({ row: nextRow, col: from.col, capture: false });
+        const doubleRow = from.row + direction * 2;
+        if (from.row === startRow && !board[doubleRow][from.col]) {
+          moves.push({ row: doubleRow, col: from.col, capture: false, special: "double" });
+        }
+      }
+      [from.col - 1, from.col + 1].forEach((col) => {
+        const row = from.row + direction;
+        if (!isInsideBoard(row, col)) return;
+        const target = board[row][col];
+        if (target && target.color !== piece.color) {
+          moves.push({ row, col, capture: true });
+        }
+      });
+      break;
+    }
+    case "rook":
+      moves.push(
+        ...getSlidingMoves(board, from, piece.color, [
+          [1, 0],
+          [-1, 0],
+          [0, 1],
+          [0, -1],
+        ])
+      );
+      break;
+    case "bishop":
+      moves.push(
+        ...getSlidingMoves(board, from, piece.color, [
+          [1, 1],
+          [1, -1],
+          [-1, 1],
+          [-1, -1],
+        ])
+      );
+      break;
+    case "queen":
+      moves.push(
+        ...getSlidingMoves(board, from, piece.color, [
+          [1, 0],
+          [-1, 0],
+          [0, 1],
+          [0, -1],
+          [1, 1],
+          [1, -1],
+          [-1, 1],
+          [-1, -1],
+        ])
+      );
+      break;
+    case "king": {
+      const offsets = [
+        [1, 0],
+        [1, 1],
+        [0, 1],
+        [-1, 1],
+        [-1, 0],
+        [-1, -1],
+        [0, -1],
+        [1, -1],
+      ];
+      offsets.forEach(([dr, dc]) => {
+        const row = from.row + dr;
+        const col = from.col + dc;
+        if (!isInsideBoard(row, col)) return;
+        const target = board[row][col];
+        if (!target || target.color !== piece.color) {
+          moves.push({ row, col, capture: !!target });
+        }
+      });
+      break;
+    }
+    case "knight": {
+      const offsets = [
+        [2, 1],
+        [1, 2],
+        [-1, 2],
+        [-2, 1],
+        [-2, -1],
+        [-1, -2],
+        [1, -2],
+        [2, -1],
+      ];
+      offsets.forEach(([dr, dc]) => {
+        const row = from.row + dr;
+        const col = from.col + dc;
+        if (!isInsideBoard(row, col)) return;
+        const target = board[row][col];
+        if (!target || target.color !== piece.color) {
+          moves.push({ row, col, capture: !!target });
+        }
+      });
+      break;
+    }
+    default:
+      break;
+  }
+
+  return moves;
+};
+
+export const movePiece = (board, from, to) => {
+  const nextBoard = cloneBoard(board);
+  const piece = nextBoard[from.row][from.col];
+  nextBoard[from.row][from.col] = null;
+  nextBoard[to.row][to.col] = piece ? { ...piece, hasMoved: true } : null;
+  return nextBoard;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+#root {
+  @apply min-h-screen;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App.jsx";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- add React entry point and Tailwind-powered global styles
- implement chess board interface with timers, move history, and controls
- provide a lightweight chess engine module for piece setup and legal move hints

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e23a84d8e4832d8479539919a2fb17